### PR TITLE
Updated config_concat.erb to support profile naming convention

### DIFF
--- a/templates/config_concat.erb
+++ b/templates/config_concat.erb
@@ -1,3 +1,7 @@
+<% if @profile_name == 'default' -%>
 [<%= @profile_name %>]
+<% else -%>
+[profile <%= @profile_name %>]
+<% end -%>
 region=<%= @aws_region %>
 output=<%= @output %>


### PR DESCRIPTION
Added conditional logic to support the profile naming convention within config, as defined by:
http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-multiple-profiles
